### PR TITLE
Add server-side QR code 3D rendering prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# QR Clothes Server Prototype
+
+This project demonstrates a server-side workflow that detects a QR code in an uploaded
+image, computes its perspective, places a 3D model accordingly, and returns a rendered
+image. The pipeline uses Python with OpenCV for detection and Blender for 3D rendering.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Ensure Blender is installed and accessible via the `blender` command.
+
+## Running
+
+```bash
+python app.py
+```
+
+Send a `POST` request to `/render` with form data:
+
+- `image`: image file containing a QR code.
+- `model` (optional): path to a `.obj` model to place.
+
+The server responds with the rendered PNG.
+
+## Notes
+
+- If `pyzbar` is unavailable, OpenCV's built-in QRCode detector is used as a fallback.
+- The Blender script uses a simple cube if no model is provided.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,56 @@
+"""Flask API server for QR code based 3D rendering."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from flask import Flask, jsonify, request, send_file
+
+from qr_perspective import detect_qr_pose
+
+app = Flask(__name__)
+
+
+@app.route("/render", methods=["POST"])
+def render_endpoint():
+    if "image" not in request.files:
+        return jsonify({"error": "missing image"}), 400
+
+    image_file = request.files["image"]
+    model_path = request.form.get("model")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_path = Path(tmpdir) / "input.png"
+        image_file.save(input_path)
+
+        pose = detect_qr_pose(str(input_path))
+        if pose is None:
+            return jsonify({"error": "QR code not detected"}), 400
+
+        output_path = Path(tmpdir) / "output.png"
+        cmd = [
+            "blender",
+            "-b",
+            "-P",
+            str(Path(__file__).with_name("render_blender.py")),
+            "--",
+            str(input_path),
+            str(output_path),
+            json.dumps(pose.matrix),
+        ]
+        if model_path:
+            cmd.append(model_path)
+
+        try:
+            subprocess.run(cmd, check=True)
+        except Exception as exc:  # pragma: no cover - requires blender
+            return jsonify({"error": f"render failed: {exc}"}), 500
+
+        return send_file(output_path, mimetype="image/png")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))

--- a/qr_perspective.py
+++ b/qr_perspective.py
@@ -1,0 +1,81 @@
+"""QR code detection and perspective transform utilities."""
+from __future__ import annotations
+import json
+from dataclasses import dataclass
+from typing import Optional, List
+
+import numpy as np
+import cv2
+
+try:
+    from pyzbar import pyzbar  # type: ignore
+    _HAS_PYZBAR = True
+except Exception:  # pragma: no cover - optional dependency
+    _HAS_PYZBAR = False
+
+
+@dataclass
+class QRPose:
+    data: str
+    corners: List[List[float]]
+    matrix: List[List[float]]
+    angle: float
+
+
+def detect_qr_pose(image_path: str) -> Optional[QRPose]:
+    """Detect a QR code and compute its perspective transform.
+
+    Parameters
+    ----------
+    image_path: str
+        Path to the image containing a QR code.
+
+    Returns
+    -------
+    Optional[QRPose]
+        Pose information or ``None`` if detection fails.
+    """
+    image = cv2.imread(image_path)
+    if image is None:
+        return None
+
+    if _HAS_PYZBAR:
+        decoded = pyzbar.decode(image)
+        if not decoded:
+            return None
+        qr = decoded[0]
+        pts = qr.polygon
+        data = qr.data.decode('utf-8')
+        src_pts = np.array([[p.x, p.y] for p in pts], dtype=np.float32)
+    else:  # fallback to OpenCV's detector
+        detector = cv2.QRCodeDetector()
+        data, src_pts = detector.detect(image)
+        if src_pts is None:
+            return None
+        src_pts = src_pts.reshape(-1, 2).astype(np.float32)
+
+    if len(src_pts) != 4:
+        return None
+
+    rect = cv2.minAreaRect(src_pts)
+    angle = float(rect[-1])
+
+    dst_pts = np.array(
+        [[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32
+    )
+    matrix = cv2.getPerspectiveTransform(src_pts, dst_pts)
+    return QRPose(
+        data=data,
+        corners=src_pts.tolist(),
+        matrix=matrix.tolist(),
+        angle=angle,
+    )
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("usage: python qr_perspective.py <image>")
+        sys.exit(1)
+    pose = detect_qr_pose(sys.argv[1])
+    print(json.dumps(pose.__dict__ if pose else None, indent=2))

--- a/render_blender.py
+++ b/render_blender.py
@@ -1,0 +1,80 @@
+"""Blender script to place a 3D model using perspective data and render."""
+import json
+import sys
+
+import bpy
+import mathutils
+
+
+def parse_args():
+    argv = sys.argv
+    if "--" in argv:
+        argv = argv[argv.index("--") + 1 :]
+    else:
+        argv = []
+    if len(argv) < 3:
+        raise SystemExit("Usage: blender -b -P render_blender.py -- <input> <output> <matrix-json> [model]")
+    image_path, output_path, matrix_json = argv[:3]
+    model_path = argv[3] if len(argv) > 3 else None
+    return image_path, output_path, matrix_json, model_path
+
+
+def setup_scene(image_path: str):
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    scene = bpy.context.scene
+
+    # Camera
+    cam_data = bpy.data.cameras.new("Camera")
+    cam_obj = bpy.data.objects.new("Camera", cam_data)
+    scene.collection.objects.link(cam_obj)
+    scene.camera = cam_obj
+    cam_obj.location = (0, -3, 1)
+    cam_obj.rotation_euler = (1.2, 0, 0)
+
+    # Light
+    light_data = bpy.data.lights.new(name="light", type="SUN")
+    light_obj = bpy.data.objects.new(name="light", object_data=light_data)
+    light_obj.location = (0, -2, 2)
+    scene.collection.objects.link(light_obj)
+
+    # Background plane with the image
+    bpy.ops.mesh.primitive_plane_add(size=2)
+    plane = bpy.context.active_object
+    mat = bpy.data.materials.new(name="bg")
+    mat.use_nodes = True
+    bsdf = mat.node_tree.nodes["Principled BSDF"]
+    tex_image = mat.node_tree.nodes.new('ShaderNodeTexImage')
+    tex_image.image = bpy.data.images.load(image_path)
+    mat.node_tree.links.new(bsdf.inputs['Base Color'], tex_image.outputs['Color'])
+    plane.data.materials.append(mat)
+    plane.location = (0, 0, 0)
+    return plane
+
+
+def load_model(model_path: str | None):
+    if model_path:
+        bpy.ops.import_scene.obj(filepath=model_path)
+        obj = bpy.context.selected_objects[0]
+    else:
+        bpy.ops.mesh.primitive_cube_add(size=0.5, location=(0, 0, 0.25))
+        obj = bpy.context.active_object
+    return obj
+
+
+def main():
+    image_path, output_path, matrix_json, model_path = parse_args()
+    plane = setup_scene(image_path)
+    obj = load_model(model_path)
+
+    matrix = mathutils.Matrix(json.loads(matrix_json))
+    obj.matrix_world = matrix
+
+    # Render
+    scene = bpy.context.scene
+    scene.render.image_settings.file_format = 'PNG'
+    scene.render.filepath = output_path
+    bpy.ops.render.render(write_still=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Flask
+opencv-python
+pyzbar
+numpy
+Pillow
+qrcode
+pytest


### PR DESCRIPTION
## Summary
- Add Flask API for processing uploaded images and rendering 3D models on QR codes
- Implement QR code detection with perspective transform and optional pyzbar usage
- Provide Blender script to load models and render results

## Testing
- `python -m py_compile app.py qr_perspective.py render_blender.py`


------
https://chatgpt.com/codex/tasks/task_e_68a78bd78e44832dbb127d5e1edf1add